### PR TITLE
refs #7 Write message from all 'now' channels

### DIFF
--- a/payload.json
+++ b/payload.json
@@ -1,11 +1,20 @@
 {
+  "token": "one-long-verification-token",
+  "team_id": "T061EG9R6",
+  "api_app_id": "A0PNCHHK2",
   "event": {
-    "type": "channel_created",
-    "channel": {
-        "id": "CKNLJ6TK5",
-        "name": "hoge",
-        "created": 1360782804,
-        "creator": "UKZ4XDGUD"
-    }    
-  }
+      "type": "message",
+      "channel": "CL24WB1SS",
+      "user": "UKMMZ1LLB",
+      "text": "やっとできた",
+      "ts": "1355517523.000005",
+      "event_ts": "1355517523.000005",
+      "channel_type": "channel"
+  },
+  "type": "event_callback",
+  "authed_teams": [
+      "T061EG9R6"
+  ],
+  "event_id": "Ev0PV52K21",
+  "event_time": 1355517523
 }

--- a/src/channelEventWatcher.js
+++ b/src/channelEventWatcher.js
@@ -5,6 +5,7 @@ const slack = new Slack();
 
 const slack_bot_token = process.env.BOT_TOKEN;
 const targetChannel = !slack_bot_token ? 'CKZGKHBV2' : 'CKSPDU47K';
+const streamChannel = 'CL1475Z16';
 const isDebug = !slack_bot_token;
 
 const channelEventWatcher = {
@@ -45,6 +46,39 @@ const channelEventWatcher = {
     const request = {
       token: slack_bot_token,
       channel: targetChannel, 
+      text: message
+    };
+    if (isDebug) {
+      console.log(request);
+    } else {
+      slack.chat.postMessage(request).then(console.log).catch(console.error);
+    }
+  },
+
+  now_channel_message_post: async (channelId, userId, text) => {
+    if (channelId === streamChannel) {
+      return;
+    }
+
+    const channel = {
+      token: slack_bot_token,
+      channel: channelId,
+    }
+    const channelInfo = await slack.channels.info(channel);
+    if (!channelInfo.channel.name.endsWith('_now')) {
+      return;
+    }
+
+    const user = {
+      token: slack_bot_token,
+      user: userId,
+    }
+    const userInfo = await slack.users.info(user);
+
+    const message = userInfo.user.profile.display_name + ' ' + SlackMention.channel(channelId) + '\n' + text;
+    const request = {
+      token: slack_bot_token,
+      channel: streamChannel,
       text: message
     };
     if (isDebug) {

--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,9 @@ exports.slackEventWatcher = async (req, res) => {
       }
       await channelEventWatcher.emoji_changed_message_post(event.subtype, name);
     }
+    if (event.type === 'message') {
+      await channelEventWatcher.now_channel_message_post(event.channel, event.user, event.text);
+    }
   }
   res.status(200).end();
 };


### PR DESCRIPTION
get users.info が権限不足で失敗している
```json
{
    "ok": false,
    "error": "missing_scope",
    "needed": "users:read",
    "provided": "identify,channels:history,channels:read,emoji:read,chat:write:bot"
}
```

この問題が解消次第動作確認